### PR TITLE
Add support for filename [name] tags in module names.

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ module.exports = function(content, sourceMap) {
 	var query = loaderUtils.parseQuery(this.query);
 	var exports = [];
 	var keys = Object.keys(query);
+	// apply name interpolation i.e. substitute strings like [name] or [ext]
+	for (var i = 0; i < keys.length; i++) {
+		keys[i] = loaderUtils.interpolateName(this, keys[i], {});
+	};
 	if(keys.length == 1 && typeof query[keys[0]] == "boolean") {
 		exports.push("module.exports = " + keys[0] + ";");
 	} else {


### PR DESCRIPTION
 If a file is called file.js one could use 'exports-loader?[name]' to add 'module.exports = file;' to the file.

Example usage in config:
```js
# webpack.conf.js
module: {
    rules: [
        {
            test: /\.js$/,
            use: [
                "imports-loader?THREE=three",
                "exports-loader?THREE.[name]"
            ],
            include: helpers.root("") + "/node_modules/three/examples/js"
        }
}
```
This allows to use all three examples as es6 or typescript modules.
```ts
import * as THREE from "three";
import "three/examples/js/loaders/ColladaLoader";
import "three/examples/js/controls/OrbitControls";

let loader = new THREE.ColladaLoader;
let orbit = new THREE.OrbitControls;
```