### PR TITLE
feat(index): add interpolation support (`loaderUtils.interpolateName`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ require("exports-loader?file,parse=helpers.parse!./file.js");
 require("exports-loader?file!./file.js");
 // adds below code to the file's source:
 //  module.exports = file;
+
+require("exports-loader?[name]!./file.js");
+// adds below code to the file's source:
+//  module.exports = file;
 ```
 
 <h2 align="center">Maintainers</h2>

--- a/index.js
+++ b/index.js
@@ -11,6 +11,10 @@ module.exports = function(content, sourceMap) {
 	var query = loaderUtils.getOptions(this) || {};
 	var exports = [];
 	var keys = Object.keys(query);
+	// apply name interpolation i.e. substitute strings like [name] or [ext]
+ +	for (var i = 0; i < keys.length; i++) {
+ +		keys[i] = loaderUtils.interpolateName(this, keys[i], {});
+ +	};
 	if(keys.length == 1 && typeof query[keys[0]] == "boolean") {
 		exports.push("module.exports = " + keys[0] + ";");
 	} else {

--- a/index.js
+++ b/index.js
@@ -12,9 +12,9 @@ module.exports = function(content, sourceMap) {
 	var exports = [];
 	var keys = Object.keys(query);
 	// apply name interpolation i.e. substitute strings like [name] or [ext]
- +	for (var i = 0; i < keys.length; i++) {
- +		keys[i] = loaderUtils.interpolateName(this, keys[i], {});
- +	};
+ 	for (var i = 0; i < keys.length; i++) {
+ 		keys[i] = loaderUtils.interpolateName(this, keys[i], {});
+ 	};
 	if(keys.length == 1 && typeof query[keys[0]] == "boolean") {
 		exports.push("module.exports = " + keys[0] + ";");
 	} else {


### PR DESCRIPTION
Since the other pull request by simonkorz has been idle for a long time, I thought I'd do it myself.
I have also made a small change in the readme to reflect the new syntax.

If a file is called file.js one could use 'exports-loader?[name]' to add 'module.exports = file;' to the file.

Example usage in config:

```js
# webpack.conf.js
module: {
    rules: [
        {
            test: /\.js$/,
            use: [
                "imports-loader?THREE=three",
                "exports-loader?THREE.[name]"
            ],
            include: helpers.root("") + "/node_modules/three/examples/js"
        }
}
```
This allows to use all three examples as es6 or typescript modules.

```js
import * as THREE from "three";
import "three/examples/js/loaders/ColladaLoader";
import "three/examples/js/controls/OrbitControls";

let loader = new THREE.ColladaLoader;
let orbit = new THREE.OrbitControls;
```
  