### PR TITLE
Replace use of `exports` with the full `module.exports`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Then add the loader to the desired `require` calls. For example:
 ```js
 require('exports-loader?file,parse=helpers.parse!./file.js');
 // adds the following code to the file's source:
-//  exports['file'] = file;
-//  exports['parse'] = helpers.parse;
+//  module.exports['file'] = file;
+//  module.exports['parse'] = helpers.parse;
 
 require('exports-loader?file!./file.js');
 // adds the following code to the file's source:

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ module.exports = function loader(content, sourceMap) {
       if (typeof query[name] === 'string') {
         mod = query[name];
       }
-      exports.push(`exports[${JSON.stringify(name)}] = (${mod});`);
+      exports.push(`module.exports[${JSON.stringify(name)}] = (${mod});`);
     });
   }
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [X] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

I had to import a third-party IIFE module which reassigned `module.exports` with utility functions for a Node environment. Since exports-loader adds individual exports to the `exports` convenience variable, and since the reassignment broke the link to `module.exports`, none of the variables exports-loader theoretically added actually made it into the final module.

This will be a problem anytime that either `exports` or `module.exports` is reassigned in the body of the source file. By writing out the full `module.exports`, it will ensure that the exported properties make it into the final module in these cases.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

I don't _think_ this should cause any breaking changes. In theory it is possible that someone did something hacky that depended on `exports` being used instead of `module.exports`. Happy to discuss the implications of this change and a migration path if necessary.

### Additional Info
